### PR TITLE
Now input parameters are parsed and validated during configuration phase while secrets are loaded on provider load event.

### DIFF
--- a/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapter.cs
+++ b/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapter.cs
@@ -1,149 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Runtime.ExceptionServices;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Web;
 
 using CoherentSolutions.Extensions.Configuration.AnyWhere.Abstractions;
 
-using Microsoft.Azure.KeyVault;
-using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-
-using Newtonsoft.Json.Linq;
 
 namespace CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault
 {
     public class AnyWhereAzureKeyVaultConfigurationSourceAdapter : IAnyWhereConfigurationAdapter
     {
-        private static class KeyVault
-        {
-            private sealed class Connection
-            {
-                private const string ACCESS_TOKEN = "access_token";
-
-                private const string ERROR_IDENTIFIER = "error";
-
-                private const string ERROR_DESCRIPTION = "error_description";
-
-                private readonly HttpClient http;
-
-                private string accessToken;
-
-                public string ApiEndpoint { get; }
-
-                public string ApiVersion { get; }
-
-                public Connection(
-                    HttpClient http,
-                    string apiEndpoint,
-                    string apiVersion)
-                {
-                    this.http = http ?? throw new ArgumentNullException(nameof(http));
-
-                    this.ApiEndpoint = apiEndpoint ?? throw new ArgumentNullException(nameof(apiEndpoint));
-                    this.ApiVersion = apiVersion ?? throw new ArgumentNullException(nameof(apiVersion));
-                }
-
-                public async Task<string> GetAccessTokenAsync(
-                    string authority,
-                    string resource,
-                    string scope)
-                {
-                    if (!string.IsNullOrEmpty(this.accessToken))
-                    {
-                        return this.accessToken;
-                    }
-
-                    var uri = $"http://{this.ApiEndpoint}/metadata/identity/oauth2/token"
-                      + $"?api-version={this.ApiVersion}"
-                      + $"&resource={HttpUtility.UrlEncode(resource)}";
-
-                    var response = await this.http.GetAsync(uri);
-                    if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == (HttpStatusCode) 429 /* Too many requests */)
-                    {
-                        throw new HttpRequestException($"The AIMS returned '{response.StatusCode}' status code, retrying if possible.");
-                    }
-
-                    var content = await response.Content.ReadAsStringAsync();
-
-                    JObject resultObject;
-                    try
-                    {
-                        resultObject = JObject.Parse(content);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new AnyWhereAzureKeyVaultConfigurationSourceAdapterException(
-                            "Invalid JSON response received from AIMS",
-                            ExceptionDispatchInfo.Capture(e).SourceException);
-                    }
-
-                    if (response.StatusCode != HttpStatusCode.OK)
-                    {
-                        throw new AnyWhereAzureKeyVaultConfigurationSourceAdapterException(
-                            $"The AIMS returned '{response.StatusCode}' status code with the following error: "
-                          + $"'{resultObject[ERROR_IDENTIFIER].Value<string>()}'/'{resultObject[ERROR_DESCRIPTION].Value<string>()}'");
-                    }
-
-                    this.accessToken = resultObject[ACCESS_TOKEN].Value<string>();
-                    return this.accessToken;
-                }
-            }
-
-            private const string AIMS_ENDPOINT = "169.254.169.254";
-
-            private const string AIMS_VERSION = "2018-10-01";
-
-            public static KeyVaultClient CreateClientUsingServicePrinciple(
-                string clientId,
-                string clientSecret)
-            {
-                return new KeyVaultClient(
-                    async (
-                        authority,
-                        resource,
-                        scope) =>
-                    {
-                        var authenticationContext = new AuthenticationContext(authority);
-                        var credentials = new ClientCredential(clientId, clientSecret);
-                        return (await authenticationContext.AcquireTokenAsync(resource, credentials)).AccessToken;
-                    });
-            }
-
-            public static KeyVaultClient CreateClientUsingManagedIdentity()
-            {
-                var http = new HttpClient
-                {
-                    DefaultRequestHeaders =
-                    {
-                        {
-                            "Metadata", "true"
-                        }
-                    }
-                };
-
-                var connection = new Connection(http, AIMS_ENDPOINT, AIMS_VERSION);
-                return new KeyVaultClient(
-                    new KeyVaultCredential(connection.GetAccessTokenAsync),
-                    http);
-            }
-        }
-
         public void ConfigureAppConfiguration(
             IConfigurationBuilder configurationBuilder,
             IAnyWhereConfigurationEnvironmentReader environmentReader)
         {
-            if (configurationBuilder == null)
+            if (configurationBuilder is null)
             {
                 throw new ArgumentNullException(nameof(configurationBuilder));
             }
 
-            if (environmentReader == null)
+            if (environmentReader is null)
             {
                 throw new ArgumentNullException(nameof(environmentReader));
             }
@@ -151,38 +26,31 @@ namespace CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault
             var vaultBaseUri = environmentReader.GetString("VAULT");
             var secretsString = environmentReader.GetString("SECRETS");
 
-            var clientId = environmentReader.GetString("CLIENT_ID", optional: true);
-            var clientSecret = environmentReader.GetString("CLIENT_SECRET", optional: true);
+            if (string.IsNullOrWhiteSpace(vaultBaseUri))
+            {
+                throw new ArgumentException("The 'VAULT' variable shouldn't has empty value");
+            }
 
             if (string.IsNullOrWhiteSpace(secretsString))
             {
-                return;
+                throw new ArgumentException("The 'SECRETS' variable shouldn't has empty value");
             }
 
-            var values = new Dictionary<string, string>();
-            using (var client = string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret)
-                ? KeyVault.CreateClientUsingManagedIdentity()
-                : KeyVault.CreateClientUsingServicePrinciple(clientId, clientSecret))
+            var secrets = new List<AnyWhereAzureKeyVaultConfigurationSourceAdapterSecret>();
+            foreach (var secret in new AnyWhereAzureKeyVaultConfigurationSourceAdapterSecretEnumerable(secretsString))
             {
-                foreach (var secret in new AnyWhereAzureKeyVaultConfigurationSourceAdapterSecretEnumerable(secretsString))
-                {
-                    var name = secret.Name;
-                    var alias = secret.Alias;
-                    var version = secret.Version;
-
-                    if (string.IsNullOrEmpty(alias))
-                    {
-                        alias = name;
-                    }
-
-                    values[alias] = client.GetSecretAsync(vaultBaseUri, name, version, CancellationToken.None)
-                       .GetAwaiter()
-                       .GetResult()
-                       .Value;
-                }
+                secrets.Add(secret);
             }
 
-            configurationBuilder.Add(new AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationSource(values));
+            var clientId = environmentReader.GetString("CLIENT_ID", optional: true);
+            var clientSecret = environmentReader.GetString("CLIENT_SECRET", optional: true);
+
+            var client = string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret)
+                ? AnyWhereAzureKeyVaultConfigurationSourceAdapterKeyVaultClientFactory.CreateClientUsingManagedIdentity()
+                : AnyWhereAzureKeyVaultConfigurationSourceAdapterKeyVaultClientFactory.CreateClientUsingServicePrinciple(clientId, clientSecret);
+
+            configurationBuilder.Add(
+                new AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationSource(vaultBaseUri, client, secrets));
         }
     }
 }

--- a/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationProvider.cs
+++ b/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationProvider.cs
@@ -1,24 +1,57 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Microsoft.Azure.KeyVault;
 using Microsoft.Extensions.Configuration;
 
 namespace CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault
 {
     public class AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationProvider : ConfigurationProvider
     {
+        private readonly string vaultBaseUri;
+
+        private readonly KeyVaultClient client;
+
+        private readonly IReadOnlyList<AnyWhereAzureKeyVaultConfigurationSourceAdapterSecret> secrets;
+
         public AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationProvider(
-            IReadOnlyDictionary<string, string> secrets)
+            in string vaultBaseUri,
+            in KeyVaultClient client,
+            in IReadOnlyList<AnyWhereAzureKeyVaultConfigurationSourceAdapterSecret> secrets)
         {
-            if (secrets == null)
+            if (string.IsNullOrWhiteSpace(vaultBaseUri))
             {
-                throw new ArgumentNullException(nameof(secrets));
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(vaultBaseUri));
             }
 
-            foreach (var kv in secrets)
+            this.vaultBaseUri = vaultBaseUri;
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.secrets = secrets ?? throw new ArgumentNullException(nameof(secrets));
+        }
+
+        public override void Load()
+        {
+            base.Load();
+
+            var result = new Dictionary<string, string>(this.secrets.Count);
+            foreach (var secret in this.secrets)
             {
-                this.Data[kv.Key] = kv.Value;
+                var name = secret.Name;
+                var alias = secret.Alias;
+                var version = secret.Version;
+
+                if (string.IsNullOrEmpty(alias))
+                {
+                    alias = name;
+                }
+
+                result[alias] = this.client.GetSecretAsync(this.vaultBaseUri, name, version)
+                   .GetAwaiter()
+                   .GetResult()
+                   .Value;
             }
+
+            this.Data = result;
         }
     }
 }

--- a/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationSource.cs
+++ b/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationSource.cs
@@ -1,24 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Microsoft.Azure.KeyVault;
 using Microsoft.Extensions.Configuration;
 
 namespace CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault
 {
     public class AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationSource : IConfigurationSource
     {
-        private readonly IReadOnlyDictionary<string, string> secrets;
+        private readonly string vaultBaseUri;
+
+        private readonly KeyVaultClient client;
+
+        private readonly IReadOnlyList<AnyWhereAzureKeyVaultConfigurationSourceAdapterSecret> secrets;
 
         public AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationSource(
-            IReadOnlyDictionary<string, string> secrets)
+            in string vaultBaseUri,
+            in KeyVaultClient client,
+            in IReadOnlyList<AnyWhereAzureKeyVaultConfigurationSourceAdapterSecret> secrets)
         {
+            if (string.IsNullOrWhiteSpace(vaultBaseUri))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(vaultBaseUri));
+            }
+
+            this.vaultBaseUri = vaultBaseUri;
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
             this.secrets = secrets ?? throw new ArgumentNullException(nameof(secrets));
         }
 
         public IConfigurationProvider Build(
             IConfigurationBuilder builder)
         {
-            return new AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationProvider(this.secrets);
+            return new AnyWhereAzureKeyVaultConfigurationSourceAdapterConfigurationProvider(
+                this.vaultBaseUri,
+                this.client,
+                this.secrets);
         }
     }
 }

--- a/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapterKeyVaultClientFactory.cs
+++ b/src/CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault/src/AnyWhereAzureKeyVaultConfigurationSourceAdapterKeyVaultClientFactory.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using System.Web;
+
+using Microsoft.Azure.KeyVault;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+using Newtonsoft.Json.Linq;
+
+namespace CoherentSolutions.Extensions.Configuration.AnyWhere.AzureKeyVault
+{
+    public static class AnyWhereAzureKeyVaultConfigurationSourceAdapterKeyVaultClientFactory
+    {
+        private sealed class MsiAccessTokenCallback
+        {
+            private const string AIMS_ENDPOINT = "169.254.169.254";
+
+            private const string AIMS_VERSION = "2018-10-01";
+
+            private const string ACCESS_TOKEN = "access_token";
+
+            private const string ERROR_IDENTIFIER = "error";
+
+            private const string ERROR_DESCRIPTION = "error_description";
+
+            private readonly HttpClient httpClient;
+
+            public MsiAccessTokenCallback(
+                HttpClient httpClient)
+            {
+                this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            }
+
+            public async Task<string> GetAccessTokenAsync(
+                string authority,
+                string resource,
+                string scope)
+            {
+                var uri = $"http://{AIMS_ENDPOINT}/metadata/identity/oauth2/token"
+                  + $"?api-version={AIMS_VERSION}"
+                  + $"&resource={HttpUtility.UrlEncode(resource)}";
+
+                var response = await this.httpClient.GetAsync(uri);
+                if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == (HttpStatusCode) 429 /* Too many requests */)
+                {
+                    throw new HttpRequestException($"The AIMS returned '{response.StatusCode}' status code, retrying if possible.");
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+
+                JObject resultObject;
+                try
+                {
+                    resultObject = JObject.Parse(content);
+                }
+                catch (Exception e)
+                {
+                    throw new AnyWhereAzureKeyVaultConfigurationSourceAdapterException(
+                        "Invalid JSON response received from AIMS",
+                        ExceptionDispatchInfo.Capture(e).SourceException);
+                }
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    throw new AnyWhereAzureKeyVaultConfigurationSourceAdapterException(
+                        $"The AIMS returned '{response.StatusCode}' status code with the following error: "
+                      + $"'{resultObject[ERROR_IDENTIFIER].Value<string>()}'/'{resultObject[ERROR_DESCRIPTION].Value<string>()}'");
+                }
+
+                return resultObject[ACCESS_TOKEN].Value<string>();
+            }
+        }
+
+        public static KeyVaultClient CreateClientUsingServicePrinciple(
+            string clientId,
+            string clientSecret)
+        {
+            return new KeyVaultClient(
+                async (
+                    authority,
+                    resource,
+                    scope) =>
+                {
+                    var authenticationContext = new AuthenticationContext(authority);
+                    var credentials = new ClientCredential(clientId, clientSecret);
+                    return (await authenticationContext.AcquireTokenAsync(resource, credentials)).AccessToken;
+                });
+        }
+
+        public static KeyVaultClient CreateClientUsingManagedIdentity()
+        {
+            var httpClient = new HttpClient
+            {
+                DefaultRequestHeaders =
+                {
+                    {
+                        "Metadata", "true"
+                    }
+                }
+            };
+
+            return new KeyVaultClient(
+                new KeyVaultCredential(new MsiAccessTokenCallback(httpClient).GetAccessTokenAsync),
+                httpClient);
+        }
+    }
+}


### PR DESCRIPTION
Fixed #19